### PR TITLE
IOTS-1012 Web Proxy Bugfix

### DIFF
--- a/network/OpenSSL/OpenSSLConnection.hpp
+++ b/network/OpenSSL/OpenSSLConnection.hpp
@@ -113,10 +113,10 @@ namespace awsiotsdk {
             std::condition_variable shutdown_timeout_condition_;
 
             // HTTP proxy
-            util::String proxy_;
-            uint16_t proxy_port_;
-            util::String proxy_endpoint_;
-            uint16_t proxy_endpoint_port_;
+            util::String proxy_{};
+            uint16_t proxy_port_{0};
+            util::String proxy_endpoint_{};
+            uint16_t proxy_endpoint_port_{0};
 
             /**
              * @brief Wait for socket FDs to become ready for read or write operations

--- a/src/util/logging/ConsoleLogSystem.cpp
+++ b/src/util/logging/ConsoleLogSystem.cpp
@@ -27,5 +27,5 @@ using namespace awsiotsdk;
 using namespace awsiotsdk::util::Logging;
 
 void ConsoleLogSystem::ProcessFormattedStatement(util::String &&statement) {
-    std::cout << statement;
+    std::cout << statement << std::flush;
 }


### PR DESCRIPTION
This PR addresses a bug in the web proxy connection that came as a result of updating to newer AWS IOT SDK code. The new code firtst tries to connect over IPv6 and falls back to IPv4. This caused a problem as the endpoint was not being restored properly when the IPv6 connection failed.

There are also some improvements to logging.